### PR TITLE
fix for handling void html element

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -21,6 +21,32 @@ function spacing() {
   return "  ".repeat(indent)
 }
 
+function isVoidElement(el){
+  return [ 'area',
+  'base',
+  'basefont',
+  'bgsound',
+  'br',
+  'col',
+  'command',
+  'embed',
+  'frame',
+  'hr',
+  'image',
+  'img',
+  'input',
+  'isindex',
+  'keygen',
+  'link',
+  'menuitem',
+  'meta',
+  'nextid',
+  'param',
+  'source',
+  'track',
+  'wbr' ].includes(el)
+}
+
 /* Convert aria-hidden to ariaHidden. From Facebook's html to jsx module. */
 function hyphenToCamelCase(string) {
   return string.replace(/-(.)/g, function (match, chr) {
@@ -95,11 +121,15 @@ let htmlElementToReScriptJsx = (node) => {
   attrsString = attrsString.join(" ")
 
   let s = spacing()
-  result.push(`${s}<${tag} ${attrsString}>`)
-  indent += 1
-  node.childNodes.forEach(node => toRescriptJsx(node))
-  indent -= 1
-  result.push(`${s}</${tag}>`)
+  if(isVoidElement(tag)){
+    result.push(`${s}<${tag} ${attrsString} />`)
+  }else{
+    result.push(`${s}<${tag} ${attrsString}>`)
+    indent += 1
+    node.childNodes.forEach(node => toRescriptJsx(node))
+    indent -= 1
+    result.push(`${s}</${tag}>`)
+  }
 
 }
 


### PR DESCRIPTION
Fixes #1 

For input 

```html
<input />
<input class="disabled" />
<br>
<div class="input-group prefix">
  <input />
</div>
<img src="img.jpg" />
<br>
<hr>
<input type="number" placeholder="Enter your favorite number">
```

Gives out:

```html

let s = React.string

@react.component
let make = () => {
  <>

    <input >
    </input>
    <input className="disabled">
    </input>
    <input className="success">
    </input>
    <input className="warning">
    </input>
    <input className="danger">
    </input>
    <br >
    </br>
    <img src="img.jpg">
    </img>
    <div className="input-group prefix">
      <span className="label prefix">
        {s("Company")}
      </span>
      <input >
      </input>
    </div>
    <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.png">
    </img>
    <br >
    </br>
    <hr >
    </hr>
    <input type_="number" placeholder="Enter your favorite number">
    </input>

  </>
}


```

Instead of 

```html
Convert HTML to ReScript JSX component

let s = React.string

@react.component
let make = () => {
  <>

    <input  />
    <input className="disabled" />
    <br  />
    <div className="input-group prefix">
      <input  />
    </div>
    <img src="img.jpg" />
    <br  />
    <hr  />
    <input type_="number" placeholder="Enter your favorite number" />

  </>
}
```

